### PR TITLE
update dgram bind/addMembership to v10.0 spec

### DIFF
--- a/lib/upnp-service.js
+++ b/lib/upnp-service.js
@@ -40,7 +40,7 @@ var UpnpService = function(device, desc) {
 	this.host = u.hostname;
 	this.port = u.port;
 	
-	this.subscriptionTimeout = 60;
+	this.subscriptionTimeout = 300; // 60;
 }
 
 util.inherits(UpnpService, EventEmitter);

--- a/lib/upnp.js
+++ b/lib/upnp.js
@@ -38,8 +38,9 @@ function ControlPoint() {
   var self = this;
   this.server.on('message', function(msg, rinfo) {self.onRequestMessage(msg, rinfo);});
   this._initParsers();
-  this.server.bind(SSDP_PORT);
-  this.server.addMembership(BROADCAST_ADDR); //fixed issue #2
+  this.server.bind(SSDP_PORT, function () {
+    this.server.addMembership(BROADCAST_ADDR); //fixed issue #2
+  }.bind(this));
 }
 util.inherits(ControlPoint, events.EventEmitter);
 exports.ControlPoint = ControlPoint;


### PR DESCRIPTION
bind changed to async-only in 10.0, so have to addMembership in a callback (see http://nodejs.org/api/dgram.html#dgram_udp_datagram_sockets).  I believe this is backwards compatible.
