### PR TITLE
Simple cleanups

### DIFF
--- a/examples/example.js
+++ b/examples/example.js
@@ -1,5 +1,5 @@
-var UpnpControlPoint = require("./lib/upnp-controlpoint").UpnpControlPoint,
-	wemo = require("./lib/wemo");
+var UpnpControlPoint = require("../lib/upnp-controlpoint").UpnpControlPoint,
+	wemo = require("../lib/wemo");
 
 var handleDevice = function(device) {
 

--- a/lib/upnp-controlpoint.js
+++ b/lib/upnp-controlpoint.js
@@ -172,6 +172,11 @@ UpnpControlPoint.prototype._getDeviceDetails = function(udn, location, callback)
 				return;
 			}
 			xml2js.parseString(resData, function(err, result) {
+                if (!result.root) {
+                    console.log("problem getting device details: no result.root");
+                    return;
+                }
+
 				var desc = result.root.device[0];
 				if (TRACE) {
 					console.log(desc.deviceType + " : " + desc.friendlyName + " : " + location);

--- a/lib/wemo.js
+++ b/lib/wemo.js
@@ -1,8 +1,5 @@
 var util = require('util'),
-	EventEmitter = require('events').EventEmitter,
-	http = require("http"),
-	url = require("url"),
-	xml2js = require('xml2js');
+	EventEmitter = require('events').EventEmitter;
 
 var TRACE = true;
 var DETAIL = false;


### PR DESCRIPTION
- made example 'require' be relative to parent
- removed unnecessary 'require' in wemo
- in upnp-controlpoint, trapped a condition where 'root' never appears
